### PR TITLE
Add seeking to audio player

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,6 +1142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b6c53306532d3c8e8087b44e6580e10db51a023cf9b433cea2ac38066b92da"
+
+[[package]]
 name = "hyper"
 version = "0.12.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,7 +1340,7 @@ dependencies = [
  "chrono",
  "flate2",
  "fnv",
- "humantime",
+ "humantime 1.3.0",
  "libc",
  "log",
  "log-mdc",
@@ -1784,6 +1790,7 @@ dependencies = [
  "gstreamer",
  "gstreamer-app",
  "gstreamer-audio",
+ "humantime 2.0.0",
  "log",
  "log4rs",
  "rand 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4.8"
 log4rs = "0.9"
 toml = "0.5.5"
 structopt = "0.2"
+humantime = "2.0"
 
 tokio = "0.1"
 tokio-process = "0.2.4"

--- a/src/command.rs
+++ b/src/command.rs
@@ -9,7 +9,8 @@ use structopt::StructOpt;
                             DisableHelpFlags,
                             DisableVersion,
                             ColorNever,
-                            NoBinaryName]",)
+                            NoBinaryName,
+                            AllowLeadingHyphen]",)
 )]
 pub enum Command {
     /// Adds url to playlist
@@ -18,6 +19,8 @@ pub enum Command {
     Play,
     /// Pauses audio playback
     Pause,
+    /// Seeks by a specified amount
+    Seek { amount: String },
     /// Stops audio playback
     Stop,
     /// Switches to the next queue entry


### PR DESCRIPTION
Adds a new "!seek" command which takes in a string that will be parsed
by humantime in addition to a '+' or '-' character that can be prefixed
to determine if it is a relative seek. Without any prefix characters the
seek will be absolute.

**Summary**
This PR fixes/implements the following **bugs/features**

* Seeking

**Closing issues**

Resolves #20 
