### PR TITLE
Fix shutdown freezing the bot

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,9 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::thread;
+use std::time::{Duration, Instant};
 
+use futures::compat::Future01CompatExt;
 use futures::future::{FutureExt, TryFutureExt};
 use log::{debug, error, info};
 use structopt::clap::AppSettings;
@@ -97,49 +99,56 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting PokeBot!");
     debug!("Received CLI arguments: {:?}", std::env::args());
 
-    tokio::run(
-        async {
-            if bot_args.local {
-                let name = bot_args.names[0].clone();
-                let id = bot_args.ids[0].clone();
+    tokio::runtime::Runtime::new()?
+        .block_on(
+            async {
+                if bot_args.local {
+                    let name = bot_args.names[0].clone();
+                    let id = bot_args.ids[0].clone();
 
-                let disconnect_cb = Box::new(move |_, _, _| {});
+                    let disconnect_cb = Box::new(move |_, _, _| {});
 
-                let bot_args = MusicBotArgs {
-                    name: name,
-                    name_index: 0,
-                    id_index: 0,
-                    local: true,
-                    address: bot_args.address.clone(),
-                    id,
-                    channel: String::from("local"),
-                    verbose: bot_args.verbose,
-                    disconnect_cb,
-                };
-                MusicBot::new(bot_args).await.1.await;
-            } else {
-                let domain = bot_args.domain.clone();
-                let bind_address = bot_args.bind_address.clone();
-                let (bot, fut) = MasterBot::new(bot_args).await;
-
-                thread::spawn(|| {
-                    let web_args = web_server::WebServerArgs {
-                        domain,
-                        bind_address,
-                        bot,
+                    let bot_args = MusicBotArgs {
+                        name: name,
+                        name_index: 0,
+                        id_index: 0,
+                        local: true,
+                        address: bot_args.address.clone(),
+                        id,
+                        channel: String::from("local"),
+                        verbose: bot_args.verbose,
+                        disconnect_cb,
                     };
-                    if let Err(e) = web_server::start(web_args) {
-                        error!("Error in web server: {}", e);
-                    }
-                });
+                    MusicBot::new(bot_args).await.1.await;
+                } else {
+                    let domain = bot_args.domain.clone();
+                    let bind_address = bot_args.bind_address.clone();
+                    let (bot, fut) = MasterBot::new(bot_args).await;
 
-                fut.await;
+                    thread::spawn(|| {
+                        let web_args = web_server::WebServerArgs {
+                            domain,
+                            bind_address,
+                            bot,
+                        };
+                        if let Err(e) = web_server::start(web_args) {
+                            error!("Error in web server: {}", e);
+                        }
+                    });
+
+                    fut.await;
+                    // Keep tokio running while the bot disconnects
+                    tokio::timer::Delay::new(Instant::now() + Duration::from_secs(1))
+                        .compat()
+                        .await
+                        .expect("Failed to wait for delay");
+                }
             }
-        }
-        .unit_error()
-        .boxed()
-        .compat(),
-    );
+            .unit_error()
+            .boxed()
+            .compat(),
+        )
+        .expect("Runtime exited on an error");
 
     Ok(())
 }

--- a/src/teamspeak/mod.rs
+++ b/src/teamspeak/mod.rs
@@ -1,5 +1,4 @@
 use std::sync::{Arc, RwLock};
-use std::time::{Duration, Instant};
 
 use futures::compat::Future01CompatExt;
 use futures01::{future::Future, sink::Sink};
@@ -223,10 +222,6 @@ impl TeamSpeakConnection {
             self.conn
                 .disconnect(opt)
                 .map_err(|e| error!("Failed to send message: {}", e)),
-        );
-        // Might or might not be required to keep tokio running while the bot disconnects
-        tokio::spawn(
-            tokio::timer::Delay::new(Instant::now() + Duration::from_secs(1)).map_err(|_| ()),
         );
     }
 }


### PR DESCRIPTION
This is kind of a work around by ignoring other futures spawned on the tokio runtime but it should not cause any actual issues since the important futures should still block the runtime.

**Summary**
This PR fixes the following **bugs**

* Application can fail to shut down on SIGINT/SIGTERM

**Closing issues**
Resolves #36
