### PR TITLE
Use channel specific subscribe over server wide

### DIFF
--- a/src/bot/master.rs
+++ b/src/bot/master.rs
@@ -200,10 +200,9 @@ impl MasterBot {
                     self.spawn_bot_for(who).await;
                 }
             }
-            MusicBotMessage::ChannelAdded(_) => {
-                // TODO Only subscribe to one channel
+            MusicBotMessage::ChannelAdded(id) => {
                 let mut cteamspeak = self.teamspeak.clone();
-                cteamspeak.subscribe_all().await;
+                cteamspeak.subscribe(id).await;
             }
             MusicBotMessage::ClientAdded(id) => {
                 let mut cteamspeak = self.teamspeak.clone();

--- a/src/bot/music.rs
+++ b/src/bot/music.rs
@@ -295,10 +295,10 @@ impl MusicBot {
         }
     }
 
-    async fn subscribe_all(&self) {
+    async fn subscribe(&self, id: ChannelId) {
         if let Some(ts) = &self.teamspeak {
             let mut ts = ts.clone();
-            ts.subscribe_all().await;
+            ts.subscribe(id).await;
         }
     }
 
@@ -446,9 +446,8 @@ impl MusicBot {
                 let old_channel = client.channel;
                 self.on_client_left_channel(old_channel).await;
             }
-            MusicBotMessage::ChannelAdded(_) => {
-                // TODO Only subscribe to one channel
-                self.subscribe_all().await;
+            MusicBotMessage::ChannelAdded(id) => {
+                self.subscribe(id).await;
             }
             MusicBotMessage::StateChange(state) => {
                 self.on_state(state).await?;


### PR DESCRIPTION
**Summary**
This PR fixes/implements the following **bugs**

* When a new channel was created the bot subscribes to all channels again instead of  just that one

