### PR TITLE
Added retry attempt when youtube-dl fails

### DIFF
--- a/src/bot/music.rs
+++ b/src/bot/music.rs
@@ -185,7 +185,7 @@ impl MusicBot {
     }
 
     pub async fn add_audio(&self, url: String, user: String) {
-        match crate::youtube_dl::get_audio_download_url(url).await {
+        match crate::youtube_dl::get_audio_download_from_url(url).await {
             Ok(mut metadata) => {
                 metadata.added_by = user;
                 info!("Found audio url: {}", metadata.url);


### PR DESCRIPTION
**Summary**
This PR fixes/implements the following **bugs/features**

* Ads a retry for youtube-dl is unable to extract video data
