### PR TITLE
Add local file searching to the search command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,6 +2341,7 @@ dependencies = [
  "toml",
  "tsclientlib",
  "tsproto-packets",
+ "walkdir",
  "xtra",
 ]
 
@@ -2644,6 +2645,15 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3701,6 +3711,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3833,6 +3854,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tsproto-packets = { git = "https://github.com/ReSpeak/tsclientlib" }
 toml = "0.5.7"
 structopt = "0.3.20"
 humantime = "2.0.1"
+anyhow = "1.0.33"
 
 slog = "2.5.2"
 slog-async = "2.5.0"
@@ -31,6 +32,11 @@ gstreamer = "0.16.4"
 gstreamer-app = "0.16.3"
 gstreamer-audio = "0.16.4"
 
+id3 = "0.6.1"
+metaflac = "0.2.4"
+base64 = "0.13.0"
+walkdir = "2.3.1"
+
 serde = "1.0.116"
 serde_json = "1.0.59"
 rand = { version = "0.7.3", features = ["small_rng"] }
@@ -43,7 +49,3 @@ actix-files = "0.4.0"
 actix-slog = "0.2.1"
 askama_actix = "0.11.1"
 askama = "0.10.3"
-anyhow = "1.0.33"
-id3 = "0.6.1"
-metaflac = "0.2.4"
-base64 = "0.13.0"

--- a/src/command.rs
+++ b/src/command.rs
@@ -16,9 +16,15 @@ use structopt::StructOpt;
 )]
 pub enum Command {
     /// Adds url to playlist
-    Add { url: Vec<String> },
+    Add {
+        #[structopt(required = true)]
+        url: Vec<String>,
+    },
     /// Adds the first video found on YouTube
-    Search { query: Vec<String> },
+    Search {
+        #[structopt(required = true)]
+        query: Vec<String>,
+    },
     /// Starts audio playback
     Play,
     /// Pauses audio playback

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::thread;
 
 use slog::{debug, error, info, o, Drain, Logger};
+use slog_async::OverflowStrategy;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
 #[cfg(unix)]
@@ -73,7 +74,10 @@ async fn main() {
         let config = log4rs::load_config_file("log4rs.yml", Default::default()).unwrap();
         let drain = LogBridge(log4rs::Logger::new(config)).fuse();
         // slog_async adds a channel because log4rs if not unwind safe
-        let drain = slog_async::Async::new(drain).build().fuse();
+        let drain = slog_async::Async::new(drain)
+            .overflow_strategy(OverflowStrategy::Block)
+            .build()
+            .fuse();
 
         Logger::root(drain, o!())
     };


### PR DESCRIPTION
The search command will now search local files first and if it can't
find any fall back to youtube-dl's "ytsearch".

**Summary**
This PR fixes/implements the following **bugs/features**

* Search command will search local files before using 'ytsearch'
* Logging will block instead of dropping logs if it has to

**Closing issues**

<!-- Put `resolves #XXXX` in your comment to auto-close the issue that your PR resolves (if such). -->
Resolves #80.
